### PR TITLE
fix(api): use environment variable for R2 endpoint

### DIFF
--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 
 const s3Client = new S3Client({
   region: "auto",
-  endpoint: `https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com`,
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
   credentials: {
     accessKeyId: process.env.R2_ACCESS_KEY_ID!,
     secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 
 const s3Client = new S3Client({
   region: "auto",
-  endpoint: `https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com`,
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
   credentials: {
     accessKeyId: process.env.R2_ACCESS_KEY_ID!,
     secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,


### PR DESCRIPTION
The S3 client was configured with a hardcoded placeholder for the R2 account ID in the endpoint URL. This caused all API calls that interact with R2 storage (uploading and transcribing) to fail with a 500 error.

This commit fixes the issue by replacing the hardcoded placeholder with the `R2_ACCOUNT_ID` environment variable, allowing the S3 client to connect to the correct R2 endpoint.